### PR TITLE
disable shutdown in case of partitioning fail

### DIFF
--- a/setup-slave.sh
+++ b/setup-slave.sh
@@ -66,11 +66,7 @@ for label in ${device_mapping[*]}; do
     [[ $ephemeral_count == 1 ]] && mount_point="/mnt" || mount_point="/mnt$ephemeral_count"
     ((ephemeral_count++))
 
-    partition_and_mount_device $device $mount_point
-    if [ $? -ne 0 ]; then
-      echo "host $HOSTNAME not healthy, terminating host."
-      shutdown -h now
-    fi
+    partition_and_mount_device $device $mount_point    
   fi
 done
 


### PR DESCRIPTION
This is not a reliable solution, some times ec2-metadata return incorrect info about the instances (m2 and m3).
